### PR TITLE
Increase version to 4.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:3.4.1
+FROM cypress/included:4.3.0
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress


### PR DESCRIPTION
Thanks to a fix for the parser errors in https://docs.cypress.io/guides/references/changelog.html#4-3-0 we can finally upgrade from 3.4.1 to 4.3.0