### PR TITLE
Increase version to 6.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:4.12.1
+FROM cypress/included:6.7.0
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress


### PR DESCRIPTION
This is a jump from 4.x to 6.x so there will be some incompatibilities and things that need updated.

https://docs.cypress.io/guides/references/migration-guide.html#Migrating-to-Cypress-6-0