### PR TITLE
Update Cypress to version 7.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:7.1.0
+FROM cypress/included:7.5.0
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:6.7.0
+FROM cypress/included:7.1.0
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress


### PR DESCRIPTION
Cypress made yet another major version update. This change brings us up to the latest version.