### PR TITLE
Added github action to publish docker images.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,14 @@
+# Workflows
+
+## docker-hub.yml
+
+Workflow is used to publish a Docker image to docker hub on release.
+
+The docker hub URL: https://hub.docker.com/r/drydockcloud/ci-cypress
+
+We use an access token that is created by member who has access to docker hub and the username and password is added to
+GitHub as a repository secret. Names are `DOCKER_USERNAME` and `DOCKER_PASSWORD` respectively.
+
+# References
+
+* https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to drydockcloud/ci-cypress in Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: drydockcloud/ci-cypress
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Secrets have been added https://github.com/drydockcloud/ci-cypress/settings/secrets/actions

I am not sure if we can test this as an open PR but will give it a try.