### PR TITLE
Multi platform builds for Cypress images

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -9,24 +9,28 @@ jobs:
     name: Push Docker image to drydockcloud/ci-cypress in Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: drydockcloud/ci-cypress
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -9,6 +9,9 @@ jobs:
     name: Push Docker image to drydockcloud/ci-cypress in Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:11.2.0
+FROM cypress/included:12.17.1
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress
@@ -16,7 +16,7 @@ COPY smoketest.cy.js /src/cypress/e2e/
 
 # Install Cypress plugins
 RUN yarn add --cwd ../ axe-core cypress-axe
-RUN yarn add --cwd ../ @testing-library/cypress@9.0.0
+RUN yarn add --cwd ../ @testing-library/cypress
 RUN yarn add --cwd ../ cypress-real-events
 RUN yarn add --cwd ../ cypress-file-upload
 RUN yarn add --cwd ../ cypress-downloadfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:12.17.1
+FROM cypress/included:11.2.0
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY smoketest.cy.js /src/cypress/e2e/
 
 # Install Cypress plugins
 RUN yarn add --cwd ../ axe-core cypress-axe
-RUN yarn add --cwd ../ @testing-library/cypress
+RUN yarn add --cwd ../ @testing-library/cypress@9.0.0
 RUN yarn add --cwd ../ cypress-real-events
 RUN yarn add --cwd ../ cypress-file-upload
 RUN yarn add --cwd ../ cypress-downloadfile


### PR DESCRIPTION
This will create arm and amd images for Cypress.

Already tagged and released new versions for Cypress 11 and Cypress 12 images. Visible at https://hub.docker.com/r/drydockcloud/ci-cypress/tags