### PR TITLE
Update Cypress to 14.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:13.17.0
+FROM cypress/included:14.5.4
 
 # Drydock environment setup
 LABEL exposed.command.single=cypress


### PR DESCRIPTION
Needs a release to push the image to docker hub. Tested locally and can successfully build the image.